### PR TITLE
Append user supplied flags to CMAKE_CXX_FLAGS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,9 @@ set(lucene++_VERSION
 # include specific modules
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 
+# Append additional CFLAGS
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${ADDITIONAL_CMAKE_CXX_FLAGS}")
+
 ####################################
 # pre-compiled headers support
 ####################################


### PR DESCRIPTION
Appends user supplied flags (via variable ADDITIONAL_CMAKE_CXX_FLAGS) to the CMAKE_CXX_FLAGS. Empty variable will have no effect.
