### PR TITLE
MC-154 Do not filter out Japanese stop tags in Japanese analyser

### DIFF
--- a/src/contrib/analyzers/kuromoji/JapaneseAnalyzer.cpp
+++ b/src/contrib/analyzers/kuromoji/JapaneseAnalyzer.cpp
@@ -31,7 +31,7 @@ JapaneseAnalyzer::JapaneseAnalyzer(LuceneVersion::Version matchVersion, const Ha
 		  nullptr,
 		  JapaneseTokenizer::DEFAULT_MODE,
 		  stopwordsIn,
-		  (stopwordsIn.empty() ? HashSet<String>::newInstance() : DefaultSetHolder::DEFAULT_STOP_TAGS),
+		  HashSet<String>::newInstance(), // Never filter out stop tags
 		  discardPunctuation)
 {
 }

--- a/src/test/contrib/analyzers/common/analysis/ja/TestJapaneseAnalyzer.cpp
+++ b/src/test/contrib/analyzers/common/analysis/ja/TestJapaneseAnalyzer.cpp
@@ -36,6 +36,16 @@ TEST_F(TestJapaneseAnalyzer, testBasicsWithoutStopWordsKeepingPunctuation)
 		newCollection<String>(L"多く", L"の", L"学生", L"が", L"試験", L"に", L"落ちる", L"た", L"。"));
 }
 
+TEST_F(TestJapaneseAnalyzer, testBasicsWithStopTags)
+{
+	std::set<Lucene::String> stopWords = {L"また"};
+
+	// stop tags ('じゃ' and 'あ' in this case) should never be filtered out
+	checkAnalyzesTo(
+		newLucene<JapaneseAnalyzer>(TEST_VERSION_CURRENT, HashSet<String>::newInstance(stopWords.begin(), stopWords.end()), true),
+		L"じゃあまた", newCollection<String>(L"じゃ", L"あ"));
+}
+
 TEST_F(TestJapaneseAnalyzer, testWeirdJapaneseNumberBaseFormMap)
 {
 	JapaneseAnalyzerPtr analyzer = newLucene<JapaneseAnalyzer>(TEST_VERSION_CURRENT);


### PR DESCRIPTION
-Details:
As only stop words are currently exposed for client customisation, stop tags should never be filtered out. This is also to be consistent with NVivo Windows.

-Details:
MC-154 : https://qsrinternational.atlassian.net/projects/MC/issues/MC-154?filter=myopenissues

-FYI: @tonyqsr @DarrenFordQSR @trungpmnguyen @VivienMeng 